### PR TITLE
Add steps for getting started with Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,24 @@ Pygame playground pour moi, et toi.
 
 ## Requirements
 
- - Python 3
+ - Python 3 (Note, there are some issues with this project and Python 3.7 on _Linux_, but Python 3.6 works! When the instructions below specify the `python` command, if you're on Linux you may need to use `python3.6` instead.)
  - vitrualenv
+ - pip
 
 ## Nice to haves
  - autoenv * autoenv doesn't exist on Windows ¯\_(ツ)_/¯
 
-## Run
 
-- clone this repo
-- in the repe, `virtualenv env` # note that autoenv will try to start a non existant env...
+## Getting Started
+
+- clone this repo with `git clone https://github.com/th3coop/Elf-Mania.git`
+- `cd Elf-Mania`
+
+## Set up the Virtual environment
+
+technically optional, but highly recommended. if you don't want to use a virtual environemt, skip to the installing dependencies section below.
+
+- in the repe, `virtualenv env` # note that autoenv will try to start a non existant env... (on linux you may need to specify python 3.6 by running `python3.6 -m virtualenv env`)
 
 *MAC*
  - `cd .. && cd [repo-name]` # This activates the virtual env or just `source env/bin/activate` in the repo
@@ -21,13 +29,15 @@ Pygame playground pour moi, et toi.
  - `env\bin\activate.bat` #activates the virtual env
 - confirm that the virtual env activated by making sure it's using `pip` from your `env` folder
 
-*MAC*
- - `which pip`
- 
-*Windows*
- - `where pip`
-- if it's not using it...well, i'm not sure why the activation step wouldn't have worked for you but...get digging.  Feel free to let me know if you found an issue and i'll update this for the usecase you hit.
-- `pip install -r requirements.txt`
+*Linux* 
+- initialize / enter the virtual environment with `source env/bin/activate`
+
+## Installing Dependencies
+
+- `pip install -r requirements.txt` (again, on linux you may need to specify python 3.6 with `python3.6 -m pip install -r requirements.txt`)
+
+## Running 
+
 - `python elf.py`
 
 ## Workflow


### PR DESCRIPTION
Before this commit, there were no directions for us Linux users, and
now, there are! If my experiences are to be believed, there's some stuff
that needs figuring in order to get up and going with Python 3.7 _on
Linux_ so the docs I'm adding here are very careful to suggest how to
use Python 3.6 instead.

Along the way, I shuffled some headers a bit. Tried not to step too much
on tone and stuff, just wanted the new info to go somewhere that seemed
sensical.

ALSO, I just added `pip` to the requirements and removed the sections
that left users wondering what might be wrong if it wasn't there. It
was actually something I had to install right along with virtualenv.

ALSO ALSO the music _is_ awesome!!!

:heart: :heart: