### PR TITLE
Remove black box around sprite

### DIFF
--- a/gameObjects.py
+++ b/gameObjects.py
@@ -26,7 +26,7 @@ class GameObject:
 
     def load_sprite(self, ):
         # Create sprite
-        self.sprite = pygame.image.load(self.img_path).convert_alpha()
+        self.sprite = pygame.image.load(self.img_path)
         self.scale_image(self.sprite)
 
     def scale_image(self, image):

--- a/spritesheet.py
+++ b/spritesheet.py
@@ -4,7 +4,7 @@ import pygame
 
 class Spritesheet(object):
     def __init__(self, filename):
-        self.sheet = pygame.image.load(filename).convert_alpha()
+        self.sheet = pygame.image.load(filename)
 
     def get_sprite(self, rectangle, colorkey=None):
         """
@@ -17,7 +17,7 @@ class Spritesheet(object):
             passing in -1 will get colour from top left corner
         """
         rect = pygame.Rect(rectangle)
-        image = pygame.Surface(rect.size).convert_alpha()
+        image = pygame.Surface(rect.size, pygame.SRCALPHA)
         image.blit(self.sheet, (0, 0), rect)
         if colorkey is not None:
             print("We are using colorkey")


### PR DESCRIPTION
Okayyyeeee. I'm going to take a stab at what I _think_ is going on and give myself credit for doing a lot of work that led to nothing but a quick fix and some lousy better understanding... :sweat_smile:

SO! I started poking around and, since you were doing a `convert_alpha()` on all your `Surface` objects, I read a little. From what I can tell, `convert_alpha` only does its magic if the images you're using aren't already in the (Red,Green,Blue,Alpha) format, and your images _are_ already in a format with an alpha channel. Like, by the nature of having a transparency, they have an alpha channel.

I introspected a bit by just printing the value of the image's alpha (`print("alpha", image.get_alpha())`). It was something! The value 255!

SECOND SO! Feeling all empowered, I read this about using a `colorkey`:
> any pixels that have the same color as the colorkey will be transparent

:joy: this is where it gets wonky though. Since we were seeing a black box, I set the color key to black + that alpha value `(0,0,0,255)` hoping to make that alpha transparent. And it did! No black box! Except. All the _other_ black on the sprite became transparent too. So lil elf had no eyes. :skull: And I was just like, oh okay having some absolute colors be off limits for transparency is #howGamesWork and I made a new `ELF ANIMATIONS.png` that converted all the true (0,0,0) black to  _very slightly not that black_. And :crystal_ball: I was like, omg I can't wait to tell @th3coop about this and make a PR :raised_hands: :raised_hands:

But still feeling shaky about what exactly was going on, I started looking for a little more info about hacking around with alphas for true transparency so I could justify what I was about to dump on ya (still not confident about how to use that word, alphas? alpha values? channels?).

THAT'S WHEN I DISCOVERED that you can use `pygame.SRCALPHA` as an argument to the Surface constructor and it just happily 'alpha blends' like, NBD.
> `SRCALPHA        0x00010000      # Blit uses source alpha blending`

No _very slightly not that black_, just actual transparency the way everyone expects it to work. :upside_down_face:

Anyway, thanks for coming to my talk. :nerd_face: 

Hope you're well and this all works for you the way it seems to for me. 

![elf-mania](https://user-images.githubusercontent.com/5607902/59907255-828fa780-93bf-11e9-9c5b-1b276a353f54.png)

Closes #3